### PR TITLE
fix: mark possible stuck clients based on time diff

### DIFF
--- a/static/dqm_style.css
+++ b/static/dqm_style.css
@@ -291,6 +291,15 @@ table.table.custom-table-striped-columns tr.table-warning-custom td:nth-child(ev
   background-color: #dfbe3a;
 }
 
+table tr.table-dark-custom td,
+table.table tbody tr td.table-dark-custom {
+  background-color: #343a40;
+}
+
+table.table.custom-table-striped-columns tr.table-dark-custom td:nth-child(even) {
+  background-color: #2c3035;
+}
+
 /* Style the buttons that are used to open the tab content */
 .tab button {
   background-color: #c1c1c1;

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,7 @@
                 <span title="Total jobs currently running" class="ms-1 badge grun" id="jobs-running-badge"></span>
                 <span title="Total jobs finished" class="ms-1 badge yrun" id="jobs-stopped-badge"></span>
                 <span title="Total jobs crashed" class="ms-1 badge rrun" id="jobs-crashed-badge"></span>
+                <span title="Total jobs stuck" class="ms-1 badge rrun" id="jobs-crashed-stuck"></span>
             </button>
         </h2>
         <div id="collapseTwo" class="accordion-collapse collapse show" aria-labelledby="headingTwo">
@@ -110,7 +111,7 @@
     // An object which acts like a configuration for the columns of the Runs table
     const runs_table_config = [
         { "title": "Last update", "hovertext": "Last job status update", "extra_classes": ["d-none", "d-md-block"] },
-        { "title": "Time Diff", "hovertext": "Time passed since last job's status update" , "format_function": (data) => {return get_time_diff_str(get_time_diff(data)) + " ago"}, "extra_classes": ["text-truncate"]},
+        { "title": "Time Diff", "hovertext": "Time passed since last job's status update" , "format_function": (data) => {return get_time_diff_str(get_time_diff(data)) + " ago"}, "extra_classes": ["text-truncate"], "diff_warning": 600},
         { "title": "Hostname", "hovertext": "Host machine where job is running", "extra_classes": ["custom-narrow-col","text-truncate"] },
         { "title": "State" },
         { "title": "Tag" },


### PR DESCRIPTION
- Color jobs list rows in black if time diff is greater than 600 seconds, which could indicate that colored clients are stuck or idling